### PR TITLE
Remove axios from TS client README

### DIFF
--- a/javascript-client/README.md
+++ b/javascript-client/README.md
@@ -16,8 +16,8 @@ yarn add django-s3-file-field
 
 ## Usage
 ```typescript
-import axios from 'axios';
-import S3FileFieldClient, { S3FileFieldProgress, S3FileFieldProgressState } from 'django-s3-file-field';
+import S3FileFieldClient, { S3FileFieldProgressState } from 'django-s3-file-field';
+import type { S3FileFieldProgress } from 'django-s3-file-field';
 
 function onUploadProgress (progress: S3FileFieldProgress) {
   if (progress.state == S3FileFieldProgressState.Sending) {
@@ -25,11 +25,8 @@ function onUploadProgress (progress: S3FileFieldProgress) {
   }
 }
 
-const apiClient = axios.create(...); // This can be used to set authentication headers, etc.
-
 const s3ffClient = new S3FileFieldClient({
   baseUrl: process.env.S3FF_BASE_URL, // e.g. 'http://localhost:8000/api/v1/s3-upload/', the path mounted in urlpatterns
-  apiConfig: apiClient.defaults, // This argument is optional
 });
 
 // This might be run in an event handler
@@ -41,11 +38,19 @@ const fieldValue = await s3ffClient.uploadFile(
   onUploadProgress, // This argument is optional
 );
 
-apiClient.post(
+// You can set this field value in your form or use it in an API call to register the S3 object to its Django field.
+// REST API example is shown below:
+fetch(
   'http://localhost:8000/api/v1/file/', // This is particular to the application
   {
-    'blob': fieldValue, // This should match the field uploaded to (e.g. 'core.File.blob')
-    ...: ...,  // Other fields for the POST request
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      blob: fieldValue, // This should match the field uploaded to (e.g. 'core.File.blob')
+      ...: ...,  // Other fields for the POST request
+    }),
   }
 );
 ```


### PR DESCRIPTION
Axios isn't necessary for downstreams. I've retained the REST API example, just using the standard library `fetch` instead.