### PR TITLE
Add pydantic type for validating and deserializing S3FF values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ minio = [
   "django-minio-storage>=0.5",
   "minio>=7",
 ]
+pydantic = [
+  "pydantic>=2",
+]
 pytest = [
   # The "fixtures.py" module (containing the "pytest" requirement) is only loaded
   # automatically via entry point by consumers who already have "pytest" installed, so

--- a/s3_file_field/pydantic.py
+++ b/s3_file_field/pydantic.py
@@ -1,0 +1,16 @@
+from typing import Annotated
+
+from pydantic import PlainValidator
+
+from s3_file_field.fields import S3PlaceholderFile
+
+
+def _convert_s3ff_value(value: str) -> str:
+    file_obj = S3PlaceholderFile.from_field(value)
+    if file_obj is None:
+        raise ValueError("Invalid S3 file field value")
+    return file_obj.name
+
+
+# This type should be used for S3FF values in Pydantic models.
+S3FileFieldValue = Annotated[str, PlainValidator(_convert_s3ff_value)]

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+import pytest
+
+from s3_file_field.pydantic import S3FileFieldValue
+
+
+class Model(BaseModel):
+    blob: S3FileFieldValue
+
+
+def test_pydantic_serializer_data_invalid() -> None:
+    with pytest.raises(ValueError, match="Invalid S3 file field value"):
+        Model(blob="invalid_key")
+
+
+def test_pydantic_serializer_is_valid(s3ff_field_value: str) -> None:
+    model = Model(blob=s3ff_field_value)
+    assert model.blob.startswith("test_key")

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ package = wheel
 extras =
     s3
     minio
+    pydantic
     pytest
 
 [testenv:lint]


### PR DESCRIPTION
This library currently provides the `s3_file_field.rest_framework.S3FileSerializerField` for downstreams to use with Django Rest Framework. However, some downstreams are now using `pydantic` instead of DRF serializers, e.g. when using `django-ninja` for REST APIs.

This PR provides the pydantic equivalent serialization helper, to be used by downstreams as follows:

```python
from pydantic import BaseModel
from s3_file_field.pydantic import S3FileFieldValue

class MyModel(BaseModel):
    my_file_field: S3FileFieldValue
```

When instantiated, this model's `my_file_field` value will be validated and converted such that it can be passed directly into an `S3FileField` Django model field.