### PR TITLE
Add S3ImageField to show/replace image file after uploading to S3

### DIFF
--- a/s3_file_field/__init__.py
+++ b/s3_file_field/__init__.py
@@ -1,4 +1,4 @@
 # The documentation should always reference s3_file_field.S3FileField
 # and this cannot change without breaking the migrations of downstream
 # projects.
-from .fields import S3FileField  # noqa: F401
+from .fields import S3FileField, S3ImageField  # noqa: F401

--- a/s3_file_field/_multipart.py
+++ b/s3_file_field/_multipart.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import math
-from typing import TYPE_CHECKING, Any, ClassVar, Iterator
+from typing import TYPE_CHECKING, Any, ClassVar, Iterator, Optional
 
 from s3_file_field._sizes import gb, mb
 
@@ -74,6 +74,7 @@ class MultipartManager:
         object_key: str,
         file_size: int,
         content_type: str,
+        acl: Optional[str] = None,
     ) -> PresignedTransfer:
         if file_size > self.max_object_size:
             raise UploadTooLargeError("File is larger than the S3 maximum object size.")
@@ -81,6 +82,7 @@ class MultipartManager:
         upload_id = self._create_upload_id(
             object_key,
             content_type,
+            acl=acl,
         )
         parts = [
             PresignedPartTransfer(
@@ -162,6 +164,7 @@ class MultipartManager:
         self,
         object_key: str,
         content_type: str,
+        acl: Optional[str] = None,
     ) -> str:
         # Require content headers here
         raise NotImplementedError

--- a/s3_file_field/_multipart_minio.py
+++ b/s3_file_field/_multipart_minio.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import minio
 
@@ -26,6 +26,7 @@ class MinioMultipartManager(MultipartManager):
         self,
         object_key: str,
         content_type: str,
+        acl: Optional[str] = None,
     ) -> str:
         return self._client._create_multipart_upload(
             bucket_name=self._bucket_name,

--- a/s3_file_field/_multipart_s3.py
+++ b/s3_file_field/_multipart_s3.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from botocore.exceptions import ClientError
 
@@ -27,7 +27,11 @@ class S3MultipartManager(MultipartManager):
         self,
         object_key: str,
         content_type: str,
+        acl: Optional[str] = None,
     ) -> str:
+        kwargs: dict[str, Any] = {}
+        if acl:
+            kwargs["ACL"] = acl
         resp = self._client.create_multipart_upload(
             Bucket=self._bucket_name,
             Key=object_key,
@@ -35,6 +39,7 @@ class S3MultipartManager(MultipartManager):
             # TODO: filename in Metadata
             # TODO: ensure ServerSideEncryption is set, even if not specified
             # TODO: use client._get_write_parameters?
+            **kwargs,
         )
         return resp["UploadId"]
 

--- a/s3_file_field/_registry.py
+++ b/s3_file_field/_registry.py
@@ -8,9 +8,9 @@ from django.core.files.storage import Storage
 
 if TYPE_CHECKING:
     # Avoid circular imports
-    from .fields import S3FileField
+    from .fields import FileFieldProtocol
 
-    FieldsDictType = WeakValueDictionary[str, S3FileField]
+    FieldsDictType = WeakValueDictionary[str, FileFieldProtocol]
     StoragesDictType = WeakValueDictionary[int, Storage]
 
 
@@ -18,7 +18,7 @@ _fields: FieldsDictType = WeakValueDictionary()
 _storages: StoragesDictType = WeakValueDictionary()
 
 
-def register_field(field: S3FileField) -> None:
+def register_field(field: FileFieldProtocol) -> None:
     field_id = field.id
     if field_id in _fields and _fields[field_id] is not field:
         # This might be called multiple times, but it should always be consistent
@@ -36,12 +36,12 @@ def register_field(field: S3FileField) -> None:
     _storages[storage_label] = storage
 
 
-def get_field(field_id: str) -> S3FileField:
+def get_field(field_id: str) -> FileFieldProtocol:
     """Get an S3FileFields by its __str__."""
     return _fields[field_id]
 
 
-def iter_fields() -> Iterator[S3FileField]:
+def iter_fields() -> Iterator[FileFieldProtocol]:
     """Iterate over the S3FileFields in use."""
     return _fields.values()
 

--- a/s3_file_field/fields.py
+++ b/s3_file_field/fields.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional, Protocol
 from uuid import uuid4
 
 from django.core import checks
+from django.core.files.storage import Storage
 from django.db.models.fields.files import FileField
+from django.forms import Field as FormField
 
 from ._multipart import MultipartManager
 from ._registry import register_field
-from .forms import S3FormFileField
+from .forms import S3FormFileField, S3FormImageFileField
 from .widgets import S3PlaceholderFile
 
 if TYPE_CHECKING:
@@ -22,7 +24,52 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class S3FileField(FileField):
+class FileFieldProtocol(Protocol):
+    form_field: type[FormField]
+    storage: Storage
+
+    def deconstruct(self) -> tuple[str, str, Sequence[Any], dict[str, Any]]:  # flake8: noqa
+        ...
+
+    @property
+    def id(self) -> str:  # flake8: noqa
+        ...
+
+    def contribute_to_class(
+        self, cls: type[models.Model], name: str, private_only: bool = False
+    ) -> None:  # flake8: noqa
+        ...
+
+    def generate_filename(
+        self,
+        instance: Optional[models.Model],
+        filename: str,
+    ) -> str:  # flake8: noqa
+        ...
+
+    @staticmethod
+    def uuid_prefix_filename(instance: models.Model, filename: str) -> str:  # flake8: noqa
+        ...
+
+    def formfield(
+        self,
+        form_class: type[forms.Field] | None = None,
+        choices_form_class: type[forms.ChoiceField] | None = None,
+        **kwargs: Any,
+    ) -> forms.Field | None:  # flake8: noqa
+        ...
+
+    def save_form_data(self, instance: models.Model, data) -> None:  # flake8: noqa
+        ...
+
+    def check(self, **kwargs: Any) -> list[CheckMessage]:  # flake8: noqa
+        ...
+
+    def _check_supported_storage_provider(self) -> list[checks.CheckMessage]:  # flake8: noqa
+        ...
+
+
+class S3FileFieldMixin:
     """
     A django model field that is similar to a file field.
 
@@ -37,10 +84,20 @@ class S3FileField(FileField):
     def __init__(self, *args, **kwargs) -> None:
         kwargs.setdefault("max_length", 2000)
         kwargs.setdefault("upload_to", self.uuid_prefix_filename)
+        if acl := kwargs.pop("acl", ""):
+            if isinstance(acl, str):
+                self.acl = acl
+            elif callable(acl):
+                self.acl = acl
+            else:
+                raise ValueError(
+                    f"The 'acl' argument to {self.__class__.__name__} must either be a string or "
+                    "a callable"
+                )
         super().__init__(*args, **kwargs)
 
-    def deconstruct(self) -> tuple[str, str, Sequence[Any], dict[str, Any]]:
-        name, path, args, kwargs = super().deconstruct()
+    def deconstruct(self: FileFieldProtocol) -> tuple[str, str, Sequence[Any], dict[str, Any]]:
+        name, path, args, kwargs = super().deconstruct()  # type: ignore [safe-super]
         if kwargs.get("max_length") == 2000:
             del kwargs["max_length"]
         if kwargs.get("upload_to") is self.uuid_prefix_filename:
@@ -56,12 +113,16 @@ class S3FileField(FileField):
         return str(self)
 
     def contribute_to_class(
-        self, cls: type[models.Model], name: str, private_only: bool = False
+        self: FileFieldProtocol, cls: type[models.Model], name: str, private_only: bool = False
     ) -> None:
         # This is executed when the Field is formally added to its containing class.
         # As a side effect, self.name is set and self.__str__ becomes usable as a unique
         # identifier for the Field.
-        super().contribute_to_class(cls, name, private_only=private_only)
+        super().contribute_to_class(  # type: ignore [safe-super]
+            cls,
+            name,
+            private_only=private_only,
+        )
         if cls.__module__ != "__fake__":
             # Django's makemigrations iteratively creates fake model instances.
             # To avoid registration collisions, don't register these.
@@ -72,7 +133,7 @@ class S3FileField(FileField):
         return f"{uuid4()}/{filename}"
 
     def formfield(
-        self,
+        self: FileFieldProtocol,
         form_class: type[forms.Field] | None = None,
         choices_form_class: type[forms.ChoiceField] | None = None,
         **kwargs: Any,
@@ -83,15 +144,16 @@ class S3FileField(FileField):
         This is an instance of "form_class", with a widget of "widget".
         """
         if MultipartManager.supported_storage(self.storage):
-            # Use S3FormFileField as a default, instead of forms.FileField from the superclass
-            form_class = S3FormFileField if form_class is None else form_class
+            # Use S3FormFileField or S3FormImageFileField as a default, instead of forms.FileField
+            # from the superclass
+            form_class = self.form_field if form_class is None else form_class
             # Allow the form and widget to lookup this field instance later, using its id
             kwargs.setdefault("model_field_id", self.id)
-        return super().formfield(
+        return super().formfield(  # type: ignore [safe-super]
             form_class=form_class, choices_form_class=choices_form_class, **kwargs
         )
 
-    def save_form_data(self, instance: models.Model, data) -> None:
+    def save_form_data(self: FileFieldProtocol, instance: models.Model, data) -> None:
         """Coerce a form field value and assign it to a model instance's field."""
         # The FileField's FileDescriptor behavior provides that when a File object is
         # assigned to the field, the content is considered uncommitted, and is saved.
@@ -101,17 +163,42 @@ class S3FileField(FileField):
         # since that will break most of the default validation.
         if isinstance(data, S3PlaceholderFile):
             data = data.name
-        super().save_form_data(instance, data)
+        super().save_form_data(instance, data)  # type: ignore [safe-super]
 
-    def check(self, **kwargs: Any) -> list[CheckMessage]:
+    def check(self: FileFieldProtocol, **kwargs: Any) -> list[CheckMessage]:
         return [
-            *super().check(**kwargs),
+            *super().check(**kwargs),  # type: ignore [safe-super]
             *self._check_supported_storage_provider(),
         ]
 
-    def _check_supported_storage_provider(self) -> list[checks.CheckMessage]:
+    def _check_supported_storage_provider(self: FileFieldProtocol) -> list[checks.CheckMessage]:
         if not MultipartManager.supported_storage(self.storage):
             msg = f"Incompatible storage type used with an {self.__class__.__name__}."
             logger.warning(msg)
             return [checks.Warning(msg, obj=self, id="s3_file_field.W001")]
         return []
+
+
+class S3FileField(S3FileFieldMixin, FileField):  # type: ignore [misc]
+    form_field = S3FormFileField
+
+
+# ImageField overrides methods to fill in the dimensions in to the (optional) height_field and
+# width_field on the model instance. But it needs to open the image file to measure the dimensions.
+# (See django.core.files.images.get_image_dimensions). Since the file is not a local file, it's
+# unlikely that anybody using S3ImageFile will need exact reverse compatability with ImageField, so
+# we subclass from FileField, and set the form field to S3ImageFileField to use the correct widget.
+class S3ImageField(S3FileFieldMixin, FileField):  # type: ignore [misc]
+    form_field = S3FormImageFileField
+
+    def formfield(
+        self,
+        form_class: type[forms.Field] | None = None,
+        choices_form_class: type[forms.ChoiceField] | None = None,
+        **kwargs: Any,
+    ) -> forms.Field | None:
+        if MultipartManager.supported_storage(self.storage):
+            kwargs.setdefault("storage", self.storage)
+        return super().formfield(  # type: ignore [misc]
+            form_class=form_class, choices_form_class=choices_form_class, **kwargs
+        )

--- a/s3_file_field/templates/s3_file_field/widgets/image_input.html
+++ b/s3_file_field/templates/s3_file_field/widgets/image_input.html
@@ -1,0 +1,31 @@
+{% block s3_image_field %}
+<label for="id_{{ widget.name }}" class="s3imageinput border border-1 mb-3 p-3 rounded-2 w-100">
+  {% block s3_image_field_initial %}
+  <div class="s3imageinput-initial mb-3" style="{% if not widget.is_initial %}display: none{% endif %}">
+    <img id="{{ widget.name }}-initial" class="position-relative rounded-circle" src="{{ widget.value.url }}" data-s3image="{{ widget.attrs.image_domain }}">
+  </div>
+  {% endblock s3_image_field_initial %}
+
+  {% block s3_image_default %}
+  <div class="s3imageinput-default" style="{% if widget.is_initial %}display: none;{% endif %}">
+    <svg id="{{ widget.name }}-default" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-person-circle flex-shrink-1" viewBox="0 0 16 16">
+      <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0"/>
+      <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1"/>
+    </svg>
+  </div>
+  {% endblock s3_image_default %}
+
+  {% block s3_image_file_input %}
+  <input type="{{ widget.type }}" name="{{ widget.name }}" class="form-control"{% include "django/forms/widgets/attrs.html" %}>
+  {% endblock s3_image_file_input %}
+
+  {% block s3_image_clear %}
+  {% if not widget.required or widget.is_initial %}
+  <input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}" class="s3fileinput-clear-checkbox d-none"{% if widget.attrs.disabled %} disabled{% endif %}>
+  {% comment %}
+  <button id="{{ widget.checkbox_name }}-clear-button" class="btn btn-danger btn-sm" data-target="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</button>
+  {% endcomment %}
+  {% endif %}
+  {% endblock s3_image_clear %}
+</label>
+{% endblock s3_image_field %}

--- a/s3_file_field/widgets.py
+++ b/s3_file_field/widgets.py
@@ -71,13 +71,13 @@ class S3FileInput(ClearableFileInput):
         js = ["s3_file_field/widget.js"]
         css = {"all": ["s3_file_field/widget.css"]}
 
-    def get_context(self, *args, **kwargs) -> dict[str, Any]:
+    def get_context(self, name, value, attrs) -> dict[str, Any]:
         # The base URL cannot be determined at the time the widget is instantiated
         # (when S3FormFileField.widget_attrs is called).
         # Additionally, because this method is called on a deep copy of the widget each
         # time it's rendered, this assignment to an instance variable is not persisted.
-        self.attrs["data-s3fileinput"] = get_base_url()
-        return super().get_context(*args, **kwargs)
+        attrs["data-s3fileinput"] = get_base_url()
+        return super().get_context(name, value, attrs)
 
     def value_from_datadict(
         self, data: Mapping[str, Any], files: MultiValueDict[str, UploadedFile], name: str
@@ -114,6 +114,18 @@ class S3FileInput(ClearableFileInput):
             and (name not in files)
             and (self.clear_checkbox_name(name) not in data)
         )
+
+
+class S3ImageFileInput(S3FileInput):
+    """Widget to render the S3 File Input with an image field preview."""
+
+    template_name = "s3_file_field/widgets/image_input.html"
+
+    class Media(S3FileInput.Media):
+        js = ["s3_file_field/imagewidget.js"]
+        css = {
+            "all": ["s3_file_field/imagewidget.css"],
+        }
 
 
 class AdminS3FileInput(S3FileInput):

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from s3_file_field.fields import S3FileField
+from s3_file_field.fields import S3FileField, S3ImageField
 
 
 class Resource(models.Model):
@@ -10,3 +10,13 @@ class Resource(models.Model):
 class MultiResource(models.Model):
     blob = S3FileField()
     optional_blob = S3FileField(blank=True)
+
+
+def get_acl(field, request):
+    return "public-read"
+
+
+class ImageResource(models.Model):
+    private = S3ImageField()
+    public = S3ImageField(acl=get_acl)
+    optional_public = S3ImageField(acl="public-read", blank=True)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -4,7 +4,17 @@ from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 import pytest
 
+from s3_file_field.fields import S3ImageField
+
 from test_app.models import Resource
+
+
+def test_s3_image_field():
+    with pytest.raises(ValueError) as exc:
+        S3ImageField(acl=3)
+    assert "The 'acl' argument to S3ImageField must either be a string or a callable" in str(
+        exc.value
+    )
 
 
 @pytest.mark.django_db()
@@ -61,4 +71,4 @@ def test_fields_clean_empty() -> None:
 
 
 def test_fields_check_success(resource: Resource) -> None:
-    assert resource._meta.get_field("blob").check() == []
+    assert resource._meta.get_field("blob").check() == []  # type: ignore [misc]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -50,7 +50,7 @@ def test_registry_get_field(s3ff_field: S3FileField) -> None:
 def test_registry_iter_fields(s3ff_field: S3FileField) -> None:
     fields = list(_registry.iter_fields())
 
-    assert len(fields) == 3
+    assert len(fields) == 6
     assert any(field is s3ff_field for field in fields)
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -70,6 +70,7 @@ def test_upload_initialization_response_serialization(
         {
             "object_key": initialization.object_key,
             "upload_id": initialization.upload_id,
+            "acl": "",
             "parts": initialization.parts,
             "upload_signature": "test-upload-signature",
         }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -29,6 +29,7 @@ def test_prepare(api_client: APIClient) -> None:
             r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/test.txt"
         ),
         "upload_id": FUZZY_UPLOAD_ID,
+        "acl": "",
         "parts": [{"part_number": 1, "size": 10, "upload_url": FUZZY_URL}],
         "upload_signature": Fuzzy(r".*:.*"),
     }
@@ -57,6 +58,7 @@ def test_prepare_two_parts(api_client: APIClient) -> None:
             r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/test.txt"
         ),
         "upload_id": FUZZY_UPLOAD_ID,
+        "acl": "",
         "parts": [
             # 5 MB size
             {"part_number": 1, "size": mb(5), "upload_url": FUZZY_URL},
@@ -83,6 +85,7 @@ def test_prepare_three_parts(api_client: APIClient) -> None:
             r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/test.txt"
         ),
         "upload_id": FUZZY_UPLOAD_ID,
+        "acl": "",
         "parts": [
             {"part_number": 1, "size": mb(5), "upload_url": FUZZY_URL},
             {"part_number": 2, "size": mb(5), "upload_url": FUZZY_URL},

--- a/widget/package.json
+++ b/widget/package.json
@@ -31,6 +31,10 @@
     "default": {
       "source": "./src/widget.ts",
       "distDir": "../s3_file_field/static/s3_file_field/"
+    },
+    "imageinput": {
+      "source": "./src/imagewidget.ts",
+      "distDir": "../s3_file_field/static/s3_file_field/"
     }
   },
   "alias": {

--- a/widget/src/S3FileInput.ts
+++ b/widget/src/S3FileInput.ts
@@ -15,7 +15,7 @@ function i18n(text: string): string {
 export default class S3FileInput {
   private readonly node: HTMLElement;
 
-  private readonly input: HTMLInputElement;
+  protected readonly input: HTMLInputElement;
 
   private readonly info: HTMLElement;
 
@@ -89,7 +89,7 @@ export default class S3FileInput {
     };
   }
 
-  private async uploadFile(file: File): Promise<string> {
+  private async uploadFile(file: File, acl?: string): Promise<string> {
     const startedEvent = new CustomEvent(EVENT_UPLOAD_STARTED, {
       detail: file,
     });
@@ -108,7 +108,7 @@ export default class S3FileInput {
         withCredentials: false,
       },
     });
-    const fieldValue = client.uploadFile(file, this.fieldId);
+    const fieldValue = client.uploadFile(file, this.fieldId, undefined, acl);
 
     const completedEvent = new CustomEvent(EVENT_UPLOAD_COMPLETE, {
       detail: fieldValue,

--- a/widget/src/S3FileInput.ts
+++ b/widget/src/S3FileInput.ts
@@ -2,6 +2,7 @@ import S3FileFieldClient, {} from 'django-s3-file-field';
 
 export const EVENT_UPLOAD_STARTED = 's3UploadStarted';
 export const EVENT_UPLOAD_COMPLETE = 's3UploadComplete';
+export const EVENT_UPLOAD_CLEARED = 's3UploadCleared';
 
 function cssClass(clazz: string): string {
   return `s3fileinput-${clazz}`;
@@ -80,6 +81,11 @@ export default class S3FileInput {
       this.input.value = '';
       this.info.innerText = '';
       this.node.classList.remove(cssClass('set'), cssClass('error'));
+      this.input.dispatchEvent(
+        new CustomEvent(EVENT_UPLOAD_CLEARED, {
+          detail: evt,
+        }),
+      );
     };
   }
 

--- a/widget/src/S3ImageInput.ts
+++ b/widget/src/S3ImageInput.ts
@@ -1,0 +1,94 @@
+import _, {MultipartInfo} from 'django-s3-file-field';
+import S3FileInput, {EVENT_UPLOAD_COMPLETE, EVENT_UPLOAD_CLEARED} from './S3FileInput.js';
+
+function imageCssClass(clazz: string): string {
+  if (clazz) {
+    return `s3imageinput-${clazz}`;
+  } else {
+    return "s3imageinput";
+  }
+}
+
+function parseUploadCompleteData (token: string): MultipartInfo {
+  return JSON.parse(
+    decodeURIComponent(
+      window.atob(
+        // Convert base64 to URL-safe base64 and parse it into bytes and then JSON
+        token.split(':')[0].replace(/-/g, '+').replace(/_/g, '/')).split('').map((c) => {
+          return `%${('00' + c.charCodeAt(0).toString(16)).slice(-2)}`;
+        }
+      ).join('')
+    )
+  );
+}
+
+export default class s3ImageFileInput extends S3FileInput {
+  private readonly draggedBackgroundClass: string;
+
+  private readonly container: HTMLInputElement;
+
+  private readonly defaultImage: HTMLInputElement;
+
+  private readonly initialContainer: HTMLInputElement;
+
+  private readonly initialImage: HTMLImageElement;
+
+  private readonly clearCheckbox: HTMLInputElement;
+
+  constructor(input: HTMLInputElement) {
+    super(input);
+
+    this.container = this.input.closest(`.${imageCssClass("")}`);
+    this.draggedBackgroundClass = this.container.dataset['draggedBackgroundClass'];
+    this.defaultImage = this.container.querySelector(`.${imageCssClass("default")}`);
+    this.initialContainer = this.container.querySelector(`.${imageCssClass("initial")}`);
+    this.initialImage = this.initialContainer.querySelector("img");
+    this.clearCheckbox = this.container.querySelector(`.${imageCssClass("clear-checkbox")}`);
+
+    this.input.addEventListener(EVENT_UPLOAD_COMPLETE, (e: CustomEvent) => {
+      e.detail.then((value) => {
+        const domain = this.initialImage.dataset["s3image"],
+          multipartInfoData: MultipartInfo = parseUploadCompleteData(value);
+        this.initialImage.src = `https://${domain}/${multipartInfoData.object_key}`;
+        this.initialContainer.style.display = null;
+        this.defaultImage.style.display = "none";
+        this.clearCheckbox.checked = false;
+      });
+    });
+
+    this.input.addEventListener(EVENT_UPLOAD_CLEARED, (e) => {
+      this.initialContainer.style.display = "none";
+      this.defaultImage.style.removeProperty("display");
+      this.clearCheckbox.checked = true;
+    });
+
+    this.container.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      this.container.classList.add(this.draggedBackgroundClass);
+    }, false);
+
+    this.container.addEventListener("dragenter", () => {
+      this.container.classList.add(this.draggedBackgroundClass);
+    });
+
+    this.container.addEventListener("dragleave", () => {
+      this.container.classList.remove(this.draggedBackgroundClass);
+    });
+
+    this.input.addEventListener("drop", (e) => {
+      e.preventDefault();
+      this.container.classList.remove(this.draggedBackgroundClass);
+      this.input.files = e.dataTransfer.files;
+      this.clearCheckbox.checked = false;
+      this.input.dispatchEvent(new Event("change"));
+    });
+
+    this.container.addEventListener("drop", (e) => {
+      e.preventDefault();
+      this.container.classList.remove(this.draggedBackgroundClass);
+      this.input.files = e.dataTransfer.files;
+      this.clearCheckbox.checked = false;
+      this.input.dispatchEvent(new Event("change"));
+    });
+  }
+}

--- a/widget/src/_variables.scss
+++ b/widget/src/_variables.scss
@@ -1,0 +1,2 @@
+$css_prefix: s3fileinput;
+$css_image_prefix: s3imageinput;

--- a/widget/src/imagestyle.scss
+++ b/widget/src/imagestyle.scss
@@ -1,0 +1,78 @@
+@use "variables" as *;
+
+ // https://stackoverflow.com/a/19068538
+.#{$css_image_prefix} {
+	border-style: dashed !important;
+}
+
+.#{$css_image_prefix}:hover {
+	border-style: dashed;
+	border-width: 1px;
+	border-width: 1px !important;
+}
+
+.#{$css_image_prefix}-initial > img {
+	width: 100%;
+}
+
+.#{$css_image_prefix}-default {
+	padding-bottom: 1rem;
+}
+
+.#{$css_prefix}-inner input[type=file] {
+	display: block;
+}
+.#{$css_prefix}-inner input[type=file],
+.#{$css_prefix}-inner .#{$css_prefix}-info {
+	padding: 0.375rem 0.75rem;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+	width: 100%;
+	appearance: none;
+}
+
+.#{$css_prefix}-inner input[type=file]::file-selector-button {
+	margin-right: 0.5rem;
+	border: none;
+	padding: 0.375rem 0.75rem;
+  	margin: -0.375rem -0.75rem;
+	-webkit-margin-end: 0.75rem;
+	margin-inline-end: 0.75rem;
+	cursor: pointer;
+}
+
+.#{$css_prefix}-spinner-wrapper {
+	border: rgb(222, 226, 230);
+	border-radius: 6px;
+	height: 100% !important;
+	width: 100% !important;
+}
+
+.#{$css_prefix}-spinner {
+	margin-left: calc(50% - 2em);
+	margin-right: calc(50% - 2em);
+	margin-top: 10%;
+	margin-bottom: 10%;
+}
+
+.#{$css_prefix}-inner .#{$css_prefix}-info {
+	flex: 1 1 auto;
+	padding: 0.375rem 0.75rem;
+	width: 1%;
+	min-width: 0;
+	overflow: hidden;
+	position: relative;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.#{$css_prefix}-clear {
+	text-align: center;
+	text-decoration: none;
+	vertical-align: middle;
+	cursor: pointer;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	user-select: none;
+}

--- a/widget/src/imagewidget.ts
+++ b/widget/src/imagewidget.ts
@@ -1,0 +1,14 @@
+import './imagestyle.scss';
+import S3ImageInput from './S3ImageInput.js';
+
+function attachToImageInputs(): void {
+  for (const element of document.querySelectorAll<HTMLInputElement>('input[data-s3fileinput]')) {
+    new S3ImageInput(element);
+  }
+}
+
+if (document.readyState !== 'loading') {
+  attachToImageInputs();
+} else {
+  document.addEventListener('DOMContentLoaded', attachToImageInputs.bind(this));
+}

--- a/widget/src/style.scss
+++ b/widget/src/style.scss
@@ -1,4 +1,4 @@
-$css_prefix: s3fileinput;
+@use "variables" as *;
 
 .#{$css_prefix}-inner {
   margin: 0;


### PR DESCRIPTION
This PR refactors a bit to add an `S3ImageField`, which extends `S3FileField`. It also comes with its own form field and widget that shows/replaces the user's selected image file after it is directly uploaded to S3.

Tested against a bucket in Digital Ocean Spaces.

For my next PR, I'll be extending this to add the ability for users to crop a selected user before it's uploaded to S3. But I wanted to get feedback early.